### PR TITLE
Create a `QStyledItemDelegate` to handle name updates to our layers.

### DIFF
--- a/src/napari_experimental/group_layer_qt.py
+++ b/src/napari_experimental/group_layer_qt.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from napari._qt.containers import QtNodeTreeModel, QtNodeTreeView
+from qtpy.QtCore import QModelIndex
+from qtpy.QtWidgets import QStyledItemDelegate, QWidget
 
-from napari_experimental.group_layer import GroupLayer
+from napari_experimental.group_layer import GroupLayer, NodeWrappingLayer
 
 if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget
@@ -17,6 +19,19 @@ class QtGroupLayerModel(QtNodeTreeModel[GroupLayer]):
         self.setRoot(root)
 
 
+class QtGroupLayerDelegate(QStyledItemDelegate):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    def setModelData(
+        self, editor: QWidget, model: QtGroupLayerModel, index: QModelIndex
+    ) -> None:
+        item_to_edit = model.getItem(index)
+        if isinstance(item_to_edit, NodeWrappingLayer) and editor.text():
+            item_to_edit.layer.name = editor.text()
+
+
 class QtGroupLayerView(QtNodeTreeView):
     _root: GroupLayer
     model_class = QtGroupLayerModel
@@ -24,3 +39,5 @@ class QtGroupLayerView(QtNodeTreeView):
     def __init__(self, root: GroupLayer, parent: QWidget = None):
         super().__init__(root, parent)
         self.setRoot(root)
+
+        self.setItemDelegate(QtGroupLayerDelegate())

--- a/src/napari_experimental/group_layer_qt.py
+++ b/src/napari_experimental/group_layer_qt.py
@@ -19,7 +19,7 @@ class QtGroupLayerModel(QtNodeTreeModel[GroupLayer]):
         self.setRoot(root)
 
 
-class QtGroupLayerDelegate(QStyledItemDelegate):
+class QtGroupLayerItemDelegate(QStyledItemDelegate):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -29,6 +29,7 @@ class QtGroupLayerDelegate(QStyledItemDelegate):
     ) -> None:
         item_to_edit = model.getItem(index)
         if isinstance(item_to_edit, NodeWrappingLayer) and editor.text():
+            # Note that if ... editor.text() prevents us setting an empty name!
             item_to_edit.layer.name = editor.text()
 
 
@@ -40,4 +41,4 @@ class QtGroupLayerView(QtNodeTreeView):
         super().__init__(root, parent)
         self.setRoot(root)
 
-        self.setItemDelegate(QtGroupLayerDelegate())
+        self.setItemDelegate(QtGroupLayerItemDelegate())


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Double-clicking a layer (technically a `NodeWrappingLayer`) in our GroupLayer display allows the user to input some text to change the name of the layer, but this change then does not take effect.

**What does this PR do?**

Adds the required custom `QStyledItemDelegate` subclass, `QtGroupLayerItemDelegate`, to handle the editing step. It is identical to the abstract class, save for how it updates the model data after receiving information from the `QLineEditor` editor. 

## References

This should hopefully address the `NodeWrappingLayers` aspect of https://github.com/brainglobe/napari-experimental/issues/5.
It should also hopefully not result in too many conflicts with the other part of that issue. In fact, it we might even be able to combine the logic of both into the same `setModelData` method.

## How has this PR been tested?

## Is this a breaking change?

## Does this PR require an update to the documentation?

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
