### PR TITLE
Add checks on napari `main`

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,17 +75,11 @@ jobs:
           python-version: '3.11'
           cache: "pip"
 
-      - name: Install plugin
-        run: pip install .[dev]
+      - name: Install tox
+        run: pip install tox
 
-      - name: Install napari from repo HEAD
-        run: pip install git+https://github.com/napari/napari.git
-
-      - name: Run test suite
-        run: pytest -vv tests/
-        # Need to use pytest here since tox will create a build
-        # envrionment that will install napari latest release,
-        # not HEAD of main!
+      - name: Run tox on napari-latest
+        run: tox -vv -e napari-latest
 
   build_sdist_wheel:
     name: Build source distribution wheel

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -55,9 +55,41 @@ jobs:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  napari-latest-test:
+    needs: [linting, manifest]
+    name: Run tests using HEAD of napari main branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup qtpy libraries
+        uses: tlambert03/setup-qt-libs@v1
+
+      - name: Setup VTK headless display
+        uses: pyvista/setup-headless-display-action@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: "pip"
+
+      - name: Install plugin
+        run: pip install .[dev]
+
+      - name: Install napari from repo HEAD
+        run: pip install git+https://github.com/napari/napari.git
+
+      - name: Run test suite
+        run: pytest -vv tests/
+        # Need to use pytest here since tox will create a build
+        # envrionment that will install napari latest release,
+        # not HEAD of main!
+
   build_sdist_wheel:
     name: Build source distribution wheel
-    needs: [test]
+    needs: [test, napari-latest-test]
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -25,24 +25,30 @@ https://napari.org/stable/plugins/index.html
 
 You can install `napari-experimental` via [pip]:
 
-    pip install napari-experimental
+```bash
+pip install napari-experimental
+```
 
+To install the latest development version:
 
+```bash
+pip install git+https://github.com/alessandrofelder/napari-experimental.git
+```
 
-To install latest development version :
+You can also install a version of the package that uses the latest version of napari (fetched from <https://github.com/napari/napari>):
 
-    pip install git+https://github.com/alessandrofelder/napari-experimental.git
-
+```bash
+pip install napari-experimental[napari-latest]
+```
 
 ## Contributing
 
-Contributions are very welcome. Tests can be run with [tox], please ensure
-the coverage at least stays the same before you submit a pull request.
+Contributions are very welcome.
+Tests can be run with [tox], please ensure the coverage at least stays the same before you submit a pull request.
 
 ## License
 
-Distributed under the terms of the [BSD-3] license,
-"napari-experimental" is free and open source software
+Distributed under the terms of the [BSD-3] license, "napari-experimental" is free and open source software
 
 ## Issues
 
@@ -59,7 +65,7 @@ If you encounter any problems, please [file an issue] along with a detailed desc
 [Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt
 [cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin
 
-[file an issue]: https://github.com/alessandrofelder/napari-experimental/issues
+[file an issue]: https://github.com/brainglobe/napari-experimental/issues
 
 [napari]: https://github.com/napari/napari
 [tox]: https://tox.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install napari-experimental
 To install the latest development version:
 
 ```bash
-pip install git+https://github.com/alessandrofelder/napari-experimental.git
+pip install git+https://github.com/brainglobe/napari-experimental.git
 ```
 
 You can also install a version of the package that uses the latest version of napari (fetched from <https://github.com/napari/napari>):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{39,310,311}-{linux,macos,windows}
+envlist =
+    py{39,310,311}-{linux,macos,windows},
+    napari-latest
 isolated_build=true
 
 [gh-actions]
@@ -97,4 +99,7 @@ passenv =
 extras =
     dev
 commands = pytest -v --color=yes --cov=napari_experimental --cov-report=xml
+
+[testenv:napari-latest]
+extras = dev, napari-latest
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ napari-experimental = "napari_experimental:napari.yaml"
 
 [project.optional-dependencies]
 dev = ["tox", "pytest", "pytest-cov", "pytest-qt"]
+napari-latest = ["napari @ git+https://github.com/napari/napari.git"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/alessandrofelder/napari-experimental/issues"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

See #17

**What does this PR do?**

- The plugin can now be installed with `pip install .[napari-latest]` which will fetch `napari` from the HEAD of the napari github repo, instead of fetching the latest stable release.
- Adds a tox environment that will run the test suite on ubuntu using this version of napari, and adds it to the CI. 

## References

Closes #17 

## How has this PR been tested?

- Local installs and runs of `tox -vv -e napari-latest` pass.
- Installing via `pip install .[napari-latest]` then `pip list | grep napari` always indicates that the installed version is that from the HEAD of the napari repo (superseding the latest stable release of napari on PyPI).

## Is this a breaking change?

No, but it does give us a future-warning of sorts against using deprecated features.

## Does this PR require an update to the documentation?

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
