### PR TITLE
Correctly Subclass our `GroupLayer`

### DIFF
--- a/src/napari_experimental/_widget.py
+++ b/src/napari_experimental/_widget.py
@@ -9,7 +9,7 @@ from napari.utils.events import Event
 from qtpy.QtCore import QModelIndex
 from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
 
-from napari_experimental.group_layer import GroupLayer, NodeWrappingLayer
+from napari_experimental.group_layer import GroupLayer, GroupLayerNode
 from napari_experimental.group_layer_qt import (
     QtGroupLayerView,
 )
@@ -29,7 +29,7 @@ class GroupLayerWidget(QWidget):
 
         self.viewer = viewer
 
-        self.group_layers = GroupLayer(self.global_layers)
+        self.group_layers = GroupLayer(*self.global_layers)
         self.group_layers_view = QtGroupLayerView(
             self.group_layers, parent=self
         )
@@ -57,10 +57,9 @@ class GroupLayerWidget(QWidget):
         the_node = self.group_layers_view.model().getItem(selected_index)
         if isinstance(the_node, GroupLayer):
             pass
-        elif isinstance(the_node, NodeWrappingLayer):
+        elif isinstance(the_node, GroupLayerNode):
             the_layer: Layer = the_node.layer
             self.global_layers.selection.select_only(the_layer)
-        pass
 
     def _new_layer_group(self) -> None:
         """ """

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -25,7 +25,11 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
 
     @property
     def name(self) -> str:
-        return f"GL-{self._name}"
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
 
     def __init__(
         self,
@@ -72,6 +76,10 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
             if not node.is_group() and node.layer is layer_ptr:
                 return True
         return False
+
+    def _node_name(self) -> str:
+        """Will be used when rendering node tree as string."""
+        return f"GL-{self.name}"
 
     def add_new_item(
         self,

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -76,7 +76,7 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
 
         :param layer_ptr: Reference to the Layer to determine is in the
         model.
-        :param recurse: If True, then all sub-trees of the tree will be checked
+        :param recursive: If True, then all sub-trees of the tree will be checked
         for the given Layer, returning True if it is found at any depth.
         """
         for item in self:

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import random
 import string
-from typing import Iterable, Optional
+from typing import Optional
 
 from napari.layers import Layer
-from napari.utils.tree import Group, Node
+from napari.utils.tree import Group
+
+from napari_experimental.group_layer_node import GroupLayerNode
 
 
 def random_string(str_length: int = 5) -> str:
@@ -14,67 +16,46 @@ def random_string(str_length: int = 5) -> str:
     )
 
 
-class NodeWrappingLayer(Node):
-
-    __default_name: str = "Node[None]"
-
-    _tracking_layer: Layer
-
-    @property
-    def is_tracking(self) -> bool:
-        return self.layer is not None
-
-    @property
-    def layer(self) -> Layer:
-        return self._tracking_layer
-
-    @layer.setter
-    def layer(self, new_ptr: Layer) -> None:
-        assert isinstance(
-            new_ptr, (Layer, None)
-        ), f"{type(new_ptr)} is not a layer!"
-        self._tracking_layer = new_ptr
+class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
+    """
+    GroupLayers are the "complex" component of the Tree structure that is used
+    to organise Layers into Groups. A GroupLayer contains GroupLayerNodes and
+    other GroupLayers (which are, in particular, a subclass of GroupLayerNode).
+    """
 
     @property
     def name(self) -> str:
-        if self.is_tracking:
-            return self.layer.name
-        else:
-            return self.__default_name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        if self.is_tracking:
-            self.layer.name = value
+        return f"GL-{self._name}"
 
     def __init__(
         self,
-        layer_ptr: Optional[Layer] = None,
+        *items_to_include: Layer | GroupLayerNode | GroupLayer,
     ):
-        Node.__init__(self, name=self.__default_name)
+        # Python seems to understand that since GroupLayerNode inherits from
+        # Node, and Group also inherits from Node, that GroupLayerNode
+        # "wins".
+        # We have to be careful about calling super() on methods inherited from
+        # Node though.
+        GroupLayerNode.__init__(self, layer_ptr=None)
+        assert self.layer is None, "GroupLayers cannot track layers!"
 
-        self.layer = layer_ptr
-
-    def __str__(self) -> str:
-        return f"Node[{self.name}]"
-
-    def __repr__(self) -> str:
-        return self.__str__()
-
-
-class GroupLayer(Group[NodeWrappingLayer]):
-
-    def __init__(self, current_layers: Iterable[Layer] = ()):
+        items_after_casting_layers = [
+            GroupLayerNode(item) if isinstance(item, Layer) else item
+            for item in items_to_include
+        ]
+        assert all(
+            isinstance(item, GroupLayerNode)
+            for item in items_after_casting_layers
+        ), (
+            "GroupLayers can only contain "
+            "GroupLayerNodes (or other GroupLayers)."
+        )
         Group.__init__(
             self,
-            children=(NodeWrappingLayer(layer) for layer in current_layers),
+            children=items_after_casting_layers,
             name=random_string(),
-            basetype=NodeWrappingLayer,
+            basetype=GroupLayerNode,
         )
-
-    def _node_name(self) -> str:
-        """Will be used when rendering node tree as string."""
-        return f"GL-{self.name}"
 
     def _check_already_tracking(self, layer_ptr: Layer) -> bool:
         """
@@ -87,14 +68,10 @@ class GroupLayer(Group[NodeWrappingLayer]):
         :param layer_ptr: Reference to the Layer to determine is in the
         model.
         """
-        for tracked_layer in self:
-            if (
-                isinstance(tracked_layer, NodeWrappingLayer)
-                and tracked_layer.layer is layer_ptr
-            ):
+        for node in self:
+            if not node.is_group() and node.layer is layer_ptr:
                 return True
-        else:
-            return False
+        return False
 
     def add_new_item(
         self,
@@ -102,7 +79,7 @@ class GroupLayer(Group[NodeWrappingLayer]):
         layer_ptr: Optional[Layer] = None,
     ) -> None:
         """
-        Insert a new NodeWrappingLayer, or GroupLayer, into the instance.
+        Insert a new GroupLayerNode, or GroupLayer, into the instance.
 
         By default, it is assumed that a new GroupLayer is being added.
         Groups added in this way may themselves be empty.
@@ -120,16 +97,36 @@ class GroupLayer(Group[NodeWrappingLayer]):
             self.insert(insert_at, GroupLayer())
         elif isinstance(layer_ptr, Layer):
             if not self._check_already_tracking(layer_ptr):
-                self.insert(insert_at, NodeWrappingLayer(layer_ptr=layer_ptr))
+                self.insert(insert_at, GroupLayerNode(layer_ptr=layer_ptr))
             else:
                 raise ValueError(
                     f"Already tracking {layer_ptr}, "
                     "but requested a new Node for it."
                 )
 
+    def is_group(self) -> bool:
+        """
+        Determines if this item is a genuine Node, or a branch
+        containing further nodes.
+
+        This method is explicitly defined to ensure that we can distinguish
+        between genuine GroupLayerNodes and GroupLayers when traversing the
+        tree.
+
+        Due to (necessarily) being a subclass of GroupLayerNode, it is possible
+        for GroupLayer instances to have the .layer property set to track a
+        Layer object. This is (currently) not intended behaviour - GroupLayers
+        are not meant to track Layers themselves. However it is possible to
+        manually set the layer tracker, and I can foresee a situation in the
+        future where this is desirable (particularly for rendering or drawing
+        purposes), so am not strictly forbidding this by overwriting the .layer
+        setter.
+        """
+        return True  # A GroupLayer is ALWAYS a branch.
+
     def remove_layer_item(self, layer_ptr: Layer, prune: bool = True) -> None:
         """
-        Removes (all instances of) NodeWrappingLayers tracking the given
+        Removes (all instances of) GroupLayerNodes tracking the given
         Layer from the tree model.
 
         If removing a layer would result in one of the Group being empty,
@@ -147,10 +144,10 @@ class GroupLayer(Group[NodeWrappingLayer]):
         :param prune: If True, branches that are empty after removing the
         layer in question will also be removed.
         """
-        for tracked_layer in self:
-            if isinstance(tracked_layer, GroupLayer):
-                tracked_layer.remove_layer_item(layer_ptr)
-                if prune and len(tracked_layer) == 0:
-                    self.remove(tracked_layer)
-            elif tracked_layer.layer is layer_ptr:
-                self.remove(tracked_layer)
+        for node in self:
+            if node.is_group():
+                node.remove_layer_item(layer_ptr)
+                if prune and len(node) == 0:
+                    self.remove(node)
+            elif node.layer is layer_ptr:
+                self.remove(node)

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -41,7 +41,7 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
         # We have to be careful about calling super() on methods inherited from
         # Node though.
         GroupLayerNode.__init__(self, layer_ptr=None)
-        assert self.layer is None, "GroupLayers cannot track layers!"
+        assert self.layer is None, "GroupLayers do not track individual layers through the .layer property."
 
         items_after_casting_layers = [
             GroupLayerNode(item) if isinstance(item, Layer) else item

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -76,8 +76,9 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
 
         :param layer_ptr: Reference to the Layer to determine is in the
         model.
-        :param recursive: If True, then all sub-trees of the tree will be checked
-        for the given Layer, returning True if it is found at any depth.
+        :param recursive: If True, then all sub-trees of the tree will be
+        checked for the given Layer, returning True if it is found at any
+        depth.
         """
         for item in self:
             if not item.is_group() and item.layer is layer_ptr:

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -41,7 +41,10 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
         # We have to be careful about calling super() on methods inherited from
         # Node though.
         GroupLayerNode.__init__(self, layer_ptr=None)
-        assert self.layer is None, "GroupLayers do not track individual layers through the .layer property."
+        assert self.layer is None, (
+            "GroupLayers do not track individual "
+            "layers through the .layer property."
+        )
 
         items_after_casting_layers = [
             GroupLayerNode(item) if isinstance(item, Layer) else item
@@ -61,7 +64,9 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
             basetype=GroupLayerNode,
         )
 
-    def _check_already_tracking(self, layer_ptr: Layer) -> bool:
+    def _check_already_tracking(
+        self, layer_ptr: Layer, recursive: bool = True
+    ) -> bool:
         """
         Return TRUE if the layer provided is already being tracked
         by a Node in this tree.
@@ -71,10 +76,15 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
 
         :param layer_ptr: Reference to the Layer to determine is in the
         model.
+        :param recurse: If True, then all sub-trees of the tree will be checked
+        for the given Layer, returning True if it is found at any depth.
         """
-        for node in self:
-            if not node.is_group() and node.layer is layer_ptr:
+        for item in self:
+            if not item.is_group() and item.layer is layer_ptr:
                 return True
+            elif item.is_group() and recursive:
+                if item._check_already_tracking(layer_ptr, recursive=True):
+                    return True
         return False
 
     def _node_name(self) -> str:

--- a/src/napari_experimental/group_layer_node.py
+++ b/src/napari_experimental/group_layer_node.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from napari.layers import Layer
+from napari.utils.tree import Node
+
+
+class GroupLayerNode(Node):
+
+    __default_name: str = "Node[None]"
+
+    _tracking_layer: Layer | None
+
+    @property
+    def is_tracking(self) -> bool:
+        return self.layer is not None
+
+    @property
+    def layer(self) -> Layer:
+        return self._tracking_layer
+
+    @layer.setter
+    def layer(self, new_ptr: Layer) -> None:
+        assert (
+            isinstance(new_ptr, Layer) or new_ptr is None
+        ), f"{type(new_ptr)} is not a layer or None!"
+        self._tracking_layer = new_ptr
+
+    @property
+    def name(self) -> str:
+        if self.is_tracking:
+            return self.layer.name
+        else:
+            return self.__default_name
+
+    def __init__(
+        self,
+        layer_ptr: Optional[Layer] = None,
+        name: Optional[str] = None,
+    ):
+        name = name if name else self.__default_name
+        Node.__init__(self, name=name)
+
+        self.layer = layer_ptr
+
+    def __str__(self) -> str:
+        return f"Node[{self.name}]"
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/src/napari_experimental/group_layer_node.py
+++ b/src/napari_experimental/group_layer_node.py
@@ -34,6 +34,11 @@ class GroupLayerNode(Node):
         else:
             return self.__default_name
 
+    @name.setter
+    def name(self, value: str) -> None:
+        if self.is_tracking:
+            self.layer.name = value
+
     def __init__(
         self,
         layer_ptr: Optional[Layer] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,43 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import numpy as np
 import pytest
-from napari.layers import Image, Points
 from qtpy.QtCore import Qt
-from skimage import data
 
-if TYPE_CHECKING:
-    import numpy.typing as npt
-
-SEED = 0
-GENERATOR = np.random.RandomState(seed=SEED)
-
-
-@pytest.fixture(scope="session")
-def blobs() -> npt.NDArray:
-    return data.binary_blobs(length=100, volume_fraction=0.05, n_dim=2)
-
-
-@pytest.fixture(scope="function")
-def image_layer(blobs) -> Image:
-    return Image(blobs, scale=(1, 2), translate=(20, 15))
-
-
-@pytest.fixture(scope="session")
-def points() -> npt.NDArray:
-    return GENERATOR.rand(10, 3) * (1, 2, 3) * 100
-
-
-@pytest.fixture(scope="session")
-def colors() -> npt.NDArray:
-    return GENERATOR.rand(10, 3)
-
-
-@pytest.fixture(scope="function")
-def points_layer(points, colors) -> Points:
-    return Points(points, face_color=colors)
+# * imports into test files are considered bad, however
+# importing fixtures defined in other files into conftest
+# means we can avoid a large conftest.py file.
+# It would be nice if ruff had an ignore block: https://github.com/astral-sh/ruff/issues/3711
+from .fixtures.conftest_group_layers import *  # noqa: F403
+from .fixtures.conftest_layers import *  # noqa: F403
 
 
 @pytest.fixture

--- a/tests/fixtures/conftest_group_layers.py
+++ b/tests/fixtures/conftest_group_layers.py
@@ -23,7 +23,7 @@ def group_layer_data(points_layer, image_layer) -> GroupLayer:
 
 
 @pytest.fixture(scope="function")
-def nested_group_data(points_layer) -> GroupLayer:
+def nested_layer_group(collection_of_layers) -> GroupLayer:
     """
     Creates a GroupLayer container with the following structure:
 
@@ -39,19 +39,14 @@ def nested_group_data(points_layer) -> GroupLayer:
     - Group_B
       - Points_B0
     """
-    points_aa0 = return_copy_with_new_name(points_layer, "Points_AA0")
-    points_aa1 = return_copy_with_new_name(points_layer, "Points_AA1")
-    group_aa = GroupLayer(points_aa0, points_aa1)
-
-    points_a0 = return_copy_with_new_name(points_layer, "Points_A0")
-    points_a1 = return_copy_with_new_name(points_layer, "Points_A1")
-    group_a = GroupLayer(points_a0, group_aa, points_a1)
-
-    points_b0 = return_copy_with_new_name(points_layer, "Points_B0")
-    group_b = GroupLayer(points_b0)
-
-    points_0 = return_copy_with_new_name(points_layer, "Points_0")
-    points_1 = return_copy_with_new_name(points_layer, "Points_1")
-
-    root = GroupLayer(points_0, group_a, points_1, group_b)
+    group_aa = GroupLayer(
+        collection_of_layers["AA0"], collection_of_layers["AA1"]
+    )
+    group_a = GroupLayer(
+        collection_of_layers["A0"], group_aa, collection_of_layers["A1"]
+    )
+    group_b = GroupLayer(collection_of_layers["B0"])
+    root = GroupLayer(
+        collection_of_layers["0"], group_a, collection_of_layers["1"], group_b
+    )
     return root

--- a/tests/fixtures/conftest_group_layers.py
+++ b/tests/fixtures/conftest_group_layers.py
@@ -3,7 +3,6 @@ from typing import Any
 
 import pytest
 from napari_experimental.group_layer import GroupLayer
-from napari_experimental.group_layer_qt import QtGroupLayerModel
 
 
 def return_copy_with_new_name(obj: Any, new_name: str = "Copy") -> Any:
@@ -56,13 +55,3 @@ def nested_group_data(points_layer) -> GroupLayer:
 
     root = GroupLayer(points_0, group_a, points_1, group_b)
     return root
-
-
-def test_qt_group_layer_model(
-    group_layer_data: GroupLayer, nested_group_data: GroupLayer, qtmodeltester
-) -> None:
-    simple = QtGroupLayerModel(root=group_layer_data)
-    qtmodeltester.check(simple)
-
-    nested = QtGroupLayerModel(nested_group_data)
-    qtmodeltester.check(nested)

--- a/tests/fixtures/conftest_layers.py
+++ b/tests/fixtures/conftest_layers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Dict
 
 import numpy as np
 import pytest
@@ -10,8 +11,21 @@ from skimage import data
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+
 SEED = 0
 GENERATOR = np.random.RandomState(seed=SEED)
+
+
+def return_copy_with_new_name(obj: Any, new_name: str = "Copy") -> Any:
+    """
+    Returns a copy of the object that is passed with the name
+    attribute set to the new name provided.
+    If an object does not have a name attribute, this method
+    will add one to the returned copy.
+    """
+    copy = deepcopy(obj)
+    copy.name = new_name
+    return copy
 
 
 @pytest.fixture(scope="session")
@@ -37,3 +51,29 @@ def colors() -> npt.NDArray:
 @pytest.fixture(scope="function")
 def points_layer(points, colors) -> Points:
     return Points(points, face_color=colors)
+
+
+@pytest.fixture(scope="function")
+def collection_of_layers(points_layer) -> Dict[str, Points]:
+    """
+    Creates a Dictionary containing with key (str) : value (Points)
+    items that can be used to instantiate other objects if necessary.
+
+    Objects persist in memory until end of test so that use of the IS
+    comparison is correctly carried out.
+
+    For a given key k, the Points layer value has the name Points_{k}.
+    Otherwise, all Points layers are identical.
+    Valid keys (all strings):
+    - 0
+    - A0
+    - A1
+    - AA0
+    - AA1
+    - 1
+    - B0
+    """
+    return {
+        key: return_copy_with_new_name(points_layer, f"Points_{key}")
+        for key in ["0", "A0", "A1", "AA0", "AA1", "1", "B0"]
+    }

--- a/tests/fixtures/conftest_layers.py
+++ b/tests/fixtures/conftest_layers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+from napari.layers import Image, Points
+from skimage import data
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+SEED = 0
+GENERATOR = np.random.RandomState(seed=SEED)
+
+
+@pytest.fixture(scope="session")
+def blobs() -> npt.NDArray:
+    return data.binary_blobs(length=100, volume_fraction=0.05, n_dim=2)
+
+
+@pytest.fixture(scope="function")
+def image_layer(blobs) -> Image:
+    return Image(blobs, scale=(1, 2), translate=(20, 15))
+
+
+@pytest.fixture(scope="session")
+def points() -> npt.NDArray:
+    return GENERATOR.rand(10, 3) * (1, 2, 3) * 100
+
+
+@pytest.fixture(scope="session")
+def colors() -> npt.NDArray:
+    return GENERATOR.rand(10, 3)
+
+
+@pytest.fixture(scope="function")
+def points_layer(points, colors) -> Points:
+    return Points(points, face_color=colors)

--- a/tests/test_group_layer.py
+++ b/tests/test_group_layer.py
@@ -7,6 +7,11 @@ from napari_experimental.group_layer_node import GroupLayerNode
 def recursively_apply_function(
     group_layer: GroupLayer, func: Callable[[GroupLayer], None]
 ) -> None:
+    """
+    Recursively apply a function to all members of a GroupLayer, and then all
+    subtrees of that GroupLayer. Functions are intended to conduct the necessary
+    assertions for a particular test.
+    """
     func(group_layer)
 
     for branch in [

--- a/tests/test_group_layer.py
+++ b/tests/test_group_layer.py
@@ -1,0 +1,53 @@
+from typing import Callable
+
+from napari_experimental.group_layer import GroupLayer
+from napari_experimental.group_layer_node import GroupLayerNode
+
+
+def recursively_apply_function(
+    group_layer: GroupLayer, func: Callable[[GroupLayer], None]
+) -> None:
+    func(group_layer)
+
+    for branch in [
+        item for item in group_layer if isinstance(item, GroupLayer)
+    ]:
+        recursively_apply_function(branch, func)
+
+
+def test_group_layer_types(nested_group_data: GroupLayer) -> None:
+    """
+    Check that everything stored in a GroupLayer is a GroupLayerNode,
+    and that any child GroupLayers also adhere to this structure.
+    """
+
+    def assert_correct_types(group_layer: GroupLayer) -> None:
+        assert isinstance(
+            group_layer, GroupLayer
+        ), f"{group_layer} is not a GroupLayer instance."
+
+        for item in group_layer:
+            assert isinstance(
+                item, GroupLayerNode
+            ), f"{item} in {group_layer} is not a GroupLayerNode instance."
+
+    recursively_apply_function(nested_group_data, assert_correct_types)
+
+
+def test_is_group(nested_group_data: GroupLayer) -> None:
+    """
+    Check that GroupLayer instances always return True
+    from their is_group() method.
+    """
+
+    def assert_correct_is_group(group_layer: GroupLayer) -> None:
+        assert (
+            group_layer.is_group()
+        ), f"{group_layer} is not flagged as a Group."
+
+        for node in [
+            item for item in group_layer if not isinstance(item, GroupLayer)
+        ]:
+            assert not node.is_group()
+
+    recursively_apply_function(nested_group_data, assert_correct_is_group)

--- a/tests/test_group_layer_qt_model.py
+++ b/tests/test_group_layer_qt_model.py
@@ -3,10 +3,10 @@ from napari_experimental.group_layer_qt import QtGroupLayerModel
 
 
 def test_qt_group_layer_model(
-    group_layer_data: GroupLayer, nested_group_data: GroupLayer, qtmodeltester
+    group_layer_data: GroupLayer, nested_layer_group: GroupLayer, qtmodeltester
 ) -> None:
     simple = QtGroupLayerModel(root=group_layer_data)
     qtmodeltester.check(simple)
 
-    nested = QtGroupLayerModel(nested_group_data)
+    nested = QtGroupLayerModel(nested_layer_group)
     qtmodeltester.check(nested)

--- a/tests/test_group_layer_qt_model.py
+++ b/tests/test_group_layer_qt_model.py
@@ -1,0 +1,12 @@
+from napari_experimental.group_layer import GroupLayer
+from napari_experimental.group_layer_qt import QtGroupLayerModel
+
+
+def test_qt_group_layer_model(
+    group_layer_data: GroupLayer, nested_group_data: GroupLayer, qtmodeltester
+) -> None:
+    simple = QtGroupLayerModel(root=group_layer_data)
+    qtmodeltester.check(simple)
+
+    nested = QtGroupLayerModel(nested_group_data)
+    qtmodeltester.check(nested)

--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -1,6 +1,6 @@
 import pytest
 from napari_experimental._widget import GroupLayerWidget
-from napari_experimental.group_layer import GroupLayer, NodeWrappingLayer
+from napari_experimental.group_layer import GroupLayer, GroupLayerNode
 from qtpy.QtWidgets import QWidget
 
 
@@ -45,7 +45,7 @@ def test_rename_layer(group_layer_widget):
     # Check current name
     node_index = group_layers_model.index(0, 0)
     node = group_layers_model.getItem(node_index)
-    assert isinstance(node, NodeWrappingLayer)
+    assert isinstance(node, GroupLayerNode)
     assert node.name == "blobs"
 
     # Rename

--- a/tests/test_qt_group_layer_model.py
+++ b/tests/test_qt_group_layer_model.py
@@ -59,7 +59,10 @@ def nested_group_data(points_layer) -> GroupLayer:
 
 
 def test_qt_group_layer_model(
-    group_layer_data: GroupLayer, qtmodeltester
+    group_layer_data: GroupLayer, nested_group_data: GroupLayer, qtmodeltester
 ) -> None:
-    model = QtGroupLayerModel(root=group_layer_data)
-    qtmodeltester.check(model)
+    simple = QtGroupLayerModel(root=group_layer_data)
+    qtmodeltester.check(simple)
+
+    nested = QtGroupLayerModel(nested_group_data)
+    qtmodeltester.check(nested)

--- a/tests/test_qt_group_layer_model.py
+++ b/tests/test_qt_group_layer_model.py
@@ -1,13 +1,65 @@
+from copy import deepcopy
+from typing import Any
+
 import pytest
 from napari_experimental.group_layer import GroupLayer
 from napari_experimental.group_layer_qt import QtGroupLayerModel
 
 
+def return_copy_with_new_name(obj: Any, new_name: str = "Copy") -> Any:
+    """
+    Returns a copy of the object that is passed with the name
+    attribute set to the new name provided.
+    If an object does not have a name attribute, this method
+    will add one to the returned copy.
+    """
+    copy = deepcopy(obj)
+    copy.name = new_name
+    return copy
+
+
 @pytest.fixture(scope="function")
 def group_layer_data(points_layer, image_layer) -> GroupLayer:
-    return GroupLayer([points_layer, image_layer])
+    return GroupLayer(points_layer, image_layer)
 
 
-def test_qt_group_layer_model(group_layer_data: GroupLayer, qtmodeltester):
+@pytest.fixture(scope="function")
+def nested_group_data(points_layer) -> GroupLayer:
+    """
+    Creates a GroupLayer container with the following structure:
+
+    Root
+    - Points_0
+    - Group_A
+      - Points_A0
+      - Group_AA
+        - Points_AA0
+        - Points_AA1
+      - Points_A1
+    - Points_1
+    - Group_B
+      - Points_B0
+    """
+    points_aa0 = return_copy_with_new_name(points_layer, "Points_AA0")
+    points_aa1 = return_copy_with_new_name(points_layer, "Points_AA1")
+    group_aa = GroupLayer(points_aa0, points_aa1)
+
+    points_a0 = return_copy_with_new_name(points_layer, "Points_A0")
+    points_a1 = return_copy_with_new_name(points_layer, "Points_A1")
+    group_a = GroupLayer(points_a0, group_aa, points_a1)
+
+    points_b0 = return_copy_with_new_name(points_layer, "Points_B0")
+    group_b = GroupLayer(points_b0)
+
+    points_0 = return_copy_with_new_name(points_layer, "Points_0")
+    points_1 = return_copy_with_new_name(points_layer, "Points_1")
+
+    root = GroupLayer(points_0, group_a, points_1, group_b)
+    return root
+
+
+def test_qt_group_layer_model(
+    group_layer_data: GroupLayer, qtmodeltester
+) -> None:
     model = QtGroupLayerModel(root=group_layer_data)
     qtmodeltester.check(model)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

- A napari `Group` subclasses from `Node`. This allows `Group`s to track other `Group`s since they are also `Node`s.
- `NodeWrappingLayer` inherits from `Node`. However, our `GroupLayer` inherits from `Group[NodeWrappingLayer]`, and therefore `GroupLayer` is not an instance of `NodeWrappingLayer`, it is only an instance of `Node`.
- As such, we actually need to properly subclass `GroupLayer` to make it a `NodeWrappingLayer`.

This set of circumstances meant that we couldn't instantiate a `GroupLayer` that already contained other `GroupLayer`s, for example.

**What does this PR do?**

- Renames `NodeWrappingLayer` to `GroupLayerNode` to better identify the class's role in the tree structure it represents. Also since our "Groups" don't track a single layer, saying they are an instance of something that tracks a layer is quite confusing.
- Breaks the `GroupLayer` and `GroupLayerNode` objects into two files, which is consistent with how `Node`s and `Group`s are organised within napari core code.
- Ensures that `GroupLayer` properly subclasses the `GroupLayerNode` class with the appropriate function overwrites in the event the multiple inheritance may give conflicting behaviours.

Since the test suite and `conftest.py` file in particular was getting quite big, this PR also splits the `conftest.py` fixtures into several smaller files, for organisational purposes. This does require a `*` import in `conftest.py`, but this [is apparently fine](https://github.com/pytest-dev/pytest/issues/3582#issuecomment-397376549) for situations like this.

## References

## How has this PR been tested?

Local testing passes, and a couple of fixtures have been added to demonstrate that we can still instantiate models based on our `GroupLayer` structures.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
