### PR TITLE
Sync GroupLayer and Main Viewer layer orders

### DIFF
--- a/src/napari_experimental/_widget.py
+++ b/src/napari_experimental/_widget.py
@@ -20,6 +20,14 @@ if TYPE_CHECKING:
 
 
 class GroupLayerWidget(QWidget):
+    """
+    Main plugin widget for interacting with GroupLayers.
+
+    Parameters
+    ----------
+    viewer : napari.viewer.Viewer
+        Main viewer instance containing (in particular) the LayerList.
+    """
 
     @property
     def global_layers(self) -> LayerList:
@@ -65,9 +73,12 @@ class GroupLayerWidget(QWidget):
         self.layout().addWidget(self.group_layers_view)
 
     def _new_layer_group(self) -> None:
-        """ """
-        # Still causes bugs when moving groups
-        # inside other groups, to investigate!
+        """
+        Action taken when creating a new, empty layer group in the widget.
+
+        TODO: Still causes a seg-fault when moving an empty group inside
+        another empty group.
+        """
         self.group_layers.add_new_group()
 
     # BEGIN FUNCTIONS TO ENSURE CONSISTENCY BETWEEN
@@ -112,8 +123,13 @@ class GroupLayerWidget(QWidget):
 
     def _on_layer_moved(self, event: Event) -> None:
         """
-        Actions to take after GroupLayers are reordered:
+        Actions taken when Nodes with the GroupLayer object are reordered:
         - Impose layer order on the main viewer after an update.
+
+        Parameters
+        ----------
+        event : Event
+            Unused, but contains the old and new indices of the moved item.
         """
         new_order = self.group_layers.flat_index_order()
         # Since the LayerList viewer indexes in the reverse to our Tree model,
@@ -131,13 +147,28 @@ class GroupLayerWidget(QWidget):
 
     def _removed_layer_in_main_viewer(self, event: Event) -> None:
         """
-        :param event: index, value (layer that was removed)
+        Action taken when a layer is removed using the main LayerList
+        viewer.
+
+        Parameters
+        ----------
+        event : Event
+            Emitted event with attributes
+            - index (of removed layer in LayerList),
+            - value (the layer that was removed).
         """
         self.group_layers.remove_layer_item(layer_ptr=event.value)
 
     def _removed_layer_in_group_layers(self, event: Event) -> None:
         """
-        index, value
+        Action taken when a layer is removed using the GroupLayers view.
+
+        Parameters
+        ----------
+        event : Event
+            Emitted event with attributes
+            - index (of the layer that was removed),
+            - value (the layer that was removed).
         """
         layer_to_remove = event.value.layer
         if layer_to_remove in self.global_layers:
@@ -146,6 +177,11 @@ class GroupLayerWidget(QWidget):
     # END FUNCTION BLOCK
 
     def _enter_debug(self) -> None:
-        """Placeholder method that allows the developer to
-        enter a DEBUG context with the widget as self."""
+        """
+        Placeholder method that allows the developer to
+        enter a DEBUG context with the widget as self.
+
+        Place a breakpoint at the pass statement below to
+        utilise.
+        """
         pass

--- a/src/napari_experimental/_widget.py
+++ b/src/napari_experimental/_widget.py
@@ -1,10 +1,9 @@
 """
 """
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from napari.components import LayerList
-from napari.layers import Layer
 from napari.utils.events import Event
 from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
 
@@ -42,6 +41,9 @@ class GroupLayerWidget(QWidget):
         self.global_layers.events.inserted.connect(self._new_layer)
         self.global_layers.events.removed.connect(self._removed_layer)
 
+        # Impose layer order whenever layers get moved
+        self.group_layers.events.moved.connect(self._on_layer_moved)
+
         self.add_group_button = QPushButton("Add empty layer group")
         self.add_group_button.clicked.connect(self._new_layer_group)
 
@@ -66,7 +68,23 @@ class GroupLayerWidget(QWidget):
         """
         self.group_layers.add_new_item(layer_ptr=event.value)
 
-    def _removed_layer(self, event: Tuple[int, Layer]) -> None:
+    def _on_layer_moved(self, event: Event) -> None:
+        """
+        Actions to take after GroupLayers are reordered:
+        - Impose layer order on the main viewer after an update.
+        """
+        new_order = self.group_layers.flat_index_order()
+
+        for new_position, layer in enumerate(
+            [
+                self.group_layers[nested_index].layer
+                for nested_index in new_order
+            ]
+        ):
+            currently_at = self.global_layers.index(layer)
+            self.global_layers.move(currently_at, dest_index=new_position)
+
+    def _removed_layer(self, event: Event) -> None:
         """
         :param event: index, value (layer that was removed)
         """

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -28,19 +28,6 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
     """
 
     @property
-    def n_items_in_tree(self) -> int:
-        """
-        Number of items in the Tree structure, recursing into Nodes that
-        are also Groups and counting those elements too.
-        """
-        n_items = 0
-        for item in self:
-            n_items += 1
-            if item.is_group():
-                n_items += item.n_items_in_tree
-        return n_items
-
-    @property
     def name(self) -> str:
         return self._name
 

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -105,40 +105,6 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
                     return True
         return False
 
-    def _flat_index_order(self) -> List[NestedIndex]:
-        """
-        Return a list of NestedIndex-es, whose order corresponds to
-        the flat order of the Nodes in the tree.
-
-        The flat order of the Nodes counts up from 0 at the root of the
-        tree, and descends into branches before continuing. An example is
-        given in the tree below:
-
-        Tree                Flat Index
-        - Node_0            0
-        - Node_1            1
-        - Group_A           n/a
-            - Node_A0       3
-            - Node_A1       4
-            - Group_AA      n/a
-                - Node_AA0  5
-            - Node_A2       6
-        - Node_2            7
-        ...
-        """
-        order: List[NestedIndex] = []
-        for item in self:
-            if item.is_group():
-                # This is a group, descend into it and append
-                # its ordering to our current ordering
-                item: GroupLayer
-                order += item._flat_index_order()
-            else:
-                # This is just a node, and it is the next one in
-                # the order
-                order.append(item.index_from_root())
-        return order
-
     def _node_name(self) -> str:
         """Will be used when rendering node tree as string."""
         return f"GL-{self.name}"
@@ -207,6 +173,40 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
                     f"Already tracking {layer_ptr}, "
                     "but requested a new Node for it."
                 )
+
+    def flat_index_order(self) -> List[NestedIndex]:
+        """
+        Return a list of NestedIndex-es, whose order corresponds to
+        the flat order of the Nodes in the tree.
+
+        The flat order of the Nodes counts up from 0 at the root of the
+        tree, and descends into branches before continuing. An example is
+        given in the tree below:
+
+        Tree                Flat Index
+        - Node_0            0
+        - Node_1            1
+        - Group_A           n/a
+            - Node_A0       3
+            - Node_A1       4
+            - Group_AA      n/a
+                - Node_AA0  5
+            - Node_A2       6
+        - Node_2            7
+        ...
+        """
+        order: List[NestedIndex] = []
+        for item in self:
+            if item.is_group():
+                # This is a group, descend into it and append
+                # its ordering to our current ordering
+                item: GroupLayer
+                order += item.flat_index_order()
+            else:
+                # This is just a node, and it is the next one in
+                # the order
+                order.append(item.index_from_root())
+        return order
 
     def is_group(self) -> bool:
         """

--- a/src/napari_experimental/group_layer_node.py
+++ b/src/napari_experimental/group_layer_node.py
@@ -7,6 +7,30 @@ from napari.utils.tree import Node
 
 
 class GroupLayerNode(Node):
+    """
+    A Node item for a tree-like data structure that has a dedicated attribute
+    for tracking a single Layer. See `napari.utils.tree` for more information
+    about Nodes.
+
+    GroupLayerNodes are the core building block of the GroupLayer display. By
+    wrapping a Layer inside a Node in this way, Layers can be organised into a
+    tree-like structure (allowing for grouping and nesting) without the hassle
+    of subclassing or mixing-in the Node class (which would require widespread
+    changes to the core napari codebase).
+
+    Parameters
+    ----------
+    layer_ptr : Layer, optional
+        The Layer object that this Node should initially track.
+    name: str, optional
+        Name to be given to the Node upon creation. The Layer retains its name.
+
+    Attributes
+    ----------
+    is_tracking
+    layer
+    name
+    """
 
     __default_name: str = "Node[None]"
 
@@ -14,10 +38,17 @@ class GroupLayerNode(Node):
 
     @property
     def is_tracking(self) -> bool:
+        """
+        Returns True if the Node is currently tracking a Layer
+        (self.Layer is not None), else False.
+        """
         return self.layer is not None
 
     @property
     def layer(self) -> Layer:
+        """
+        The (pointer to the) Layer that the Node is currently tracking.
+        """
         return self._tracking_layer
 
     @layer.setter
@@ -29,6 +60,12 @@ class GroupLayerNode(Node):
 
     @property
     def name(self) -> str:
+        """
+        Name of the Node.
+
+        If the Node is tracking a Layer, returns the name of the Layer.
+        Otherwise, returns the internal name of the Node.
+        """
         if self.is_tracking:
             return self.layer.name
         else:

--- a/src/napari_experimental/group_layer_qt.py
+++ b/src/napari_experimental/group_layer_qt.py
@@ -12,6 +12,17 @@ if TYPE_CHECKING:
 
 
 class QtGroupLayerModel(QtNodeTreeModel[GroupLayer]):
+    """
+    A QTreeModel that works with the GroupLayer tree structure.
+    See `napari._qt.containers.QtNodeTreeModel` for more information.
+
+    Parameters
+    ----------
+    root : GroupLayer
+        The root object from which to form the model.
+    parent : QWidget, optional
+        Parent QObject for the instance.
+    """
 
     def __init__(self, root: GroupLayer, parent: QWidget = None):
         super().__init__(root, parent)
@@ -48,6 +59,18 @@ class QtGroupLayerModel(QtNodeTreeModel[GroupLayer]):
 
 
 class QtGroupLayerView(QtNodeTreeView):
+    """
+    A QTreeView that works with the QtGroupLayerModel model.
+    See `napari._qt.containers.QtNodeTreeView` for more information.
+
+    Parameters
+    ----------
+    root : GroupLayer
+        The root object from which to form the model.
+    parent : QWidget, optional
+        Parent QObject for the instance.
+    """
+
     _root: GroupLayer
     model_class = QtGroupLayerModel
 

--- a/tests/test_group_layer.py
+++ b/tests/test_group_layer.py
@@ -100,7 +100,7 @@ def test_flat_index(nested_layer_group: GroupLayer) -> None:
     - Group_B
       - Points_B0
     """
-    flat_order = nested_layer_group._flat_index_order()
+    flat_order = nested_layer_group.flat_index_order()
     expected_flat_order = [
         (0,),  # Points_0
         (1, 0),  # Points_A0

--- a/tests/test_group_layer.py
+++ b/tests/test_group_layer.py
@@ -80,13 +80,13 @@ def test_check_is_already_tracking(
     expected_result: bool,
 ):
     assert (
-        nested_layer_group._check_already_tracking(
+        nested_layer_group.check_already_tracking(
             layer_ptr=collection_of_layers[layer_key], recursive=recursive
         )
         == expected_result
     ), (
         f"Incorrect result (expected {expected_result}) "
-        f"for _check_already_tracking (with recursive = {recursive})"
+        f"for check_already_tracking (with recursive = {recursive})"
     )
 
 
@@ -184,9 +184,9 @@ def test_add_group(
     ].is_group(), "Group added in the incorrect location."
 
     added_group: GroupLayer = nested_layer_group[add_at_location]
-    assert added_group._check_already_tracking(
+    assert added_group.check_already_tracking(
         pts_1
-    ) and added_group._check_already_tracking(
+    ) and added_group.check_already_tracking(
         pts_2
     ), "Points layers were not added to the new Group upon creation."
     assert (

--- a/tests/test_group_layer.py
+++ b/tests/test_group_layer.py
@@ -85,3 +85,34 @@ def test_check_is_already_tracking(
         f"Incorrect result (expected {expected_result}) "
         f"for _check_already_tracking (with recursive = {recursive})"
     )
+
+
+def test_flat_index(nested_layer_group: GroupLayer) -> None:
+    """
+    - Points_0
+    - Group_A
+      - Points_A0
+      - Group_AA
+        - Points_AA0
+        - Points_AA1
+      - Points_A1
+    - Points_1
+    - Group_B
+      - Points_B0
+    """
+    flat_order = nested_layer_group._flat_index_order()
+    expected_flat_order = [
+        (0,),  # Points_0
+        (1, 0),  # Points_A0
+        (1, 1, 0),  # Points_AA0
+        (1, 1, 1),  # Points_AA1
+        (1, 2),  # Points_A1
+        (2,),  # Points_1
+        (3, 0),  # Points_B0
+    ]
+    for i, returned_nested_index in enumerate(flat_order):
+        expected_nested_index = expected_flat_order[i]
+        assert expected_nested_index == returned_nested_index, (
+            f"Mismatch at position {i}: "
+            f"got {returned_nested_index} but expected {expected_nested_index}"
+        )

--- a/tests/test_group_layer.py
+++ b/tests/test_group_layer.py
@@ -2,8 +2,11 @@ from typing import Callable, Dict
 
 import pytest
 from napari.layers import Points
+from napari.utils.events.containers._nested_list import NestedIndex
 from napari_experimental.group_layer import GroupLayer
 from napari_experimental.group_layer_node import GroupLayerNode
+
+from .fixtures.conftest_layers import return_copy_with_new_name
 
 
 def recursively_apply_function(
@@ -116,3 +119,76 @@ def test_flat_index(nested_layer_group: GroupLayer) -> None:
             f"Mismatch at position {i}: "
             f"got {returned_nested_index} but expected {expected_nested_index}"
         )
+
+
+@pytest.mark.parametrize(
+    ["location", "expected_location"],
+    [
+        pytest.param(None, (-1), id="Default location"),
+        pytest.param((1, 1), (1, 1), id="Inside a sub-Group"),
+    ],
+)
+def test_add_layer(
+    nested_layer_group: GroupLayer,
+    points_layer: Points,
+    location: NestedIndex,
+    expected_location: NestedIndex,
+) -> None:
+    nested_layer_group.add_new_layer(points_layer, location=location)
+    assert nested_layer_group[expected_location].layer == points_layer, (
+        f"Layer was not inserted at {expected_location} "
+        f"(given location argument {location})."
+    )
+
+
+def test_add_layer_failure_cases(
+    nested_layer_group: GroupLayer, points_layer: Points
+) -> None:
+    # Cannot add a Layer to a Node object - target must be a space in a Group
+    pts_added_to_a_node = return_copy_with_new_name(
+        points_layer, "Add to a Node"
+    )
+    with pytest.raises(
+        ValueError,
+        match="Item at (.*) is not a Group",
+    ):
+        nested_layer_group.add_new_layer(pts_added_to_a_node, (1, 0, 1))
+
+    # Must provide a Layer pointer to create a new Node
+    with pytest.raises(
+        ValueError,
+        match="A Layer must be provided when (.*)",
+    ):
+        nested_layer_group.add_new_layer(None)
+
+    # Cannot track the same Layer twice
+    nested_layer_group.add_new_layer(points_layer)  # Add the layer
+    with pytest.raises(
+        RuntimeError, match="Group Node\[.*\] is already tracking"
+    ):
+        nested_layer_group.add_new_layer(points_layer)  # Try to add it again
+
+
+def test_add_group(
+    nested_layer_group: GroupLayer,
+    points_layer: Points,
+) -> None:
+    add_at_location = (2,)
+    pts_1 = return_copy_with_new_name(points_layer, "pts_1")
+    pts_2 = return_copy_with_new_name(points_layer, "pts_2")
+
+    nested_layer_group.add_new_group(pts_1, pts_2, location=add_at_location)
+
+    assert nested_layer_group[
+        add_at_location
+    ].is_group(), "Group added in the incorrect location."
+
+    added_group: GroupLayer = nested_layer_group[add_at_location]
+    assert added_group._check_already_tracking(
+        pts_1
+    ) and added_group._check_already_tracking(
+        pts_2
+    ), "Points layers were not added to the new Group upon creation."
+    assert (
+        len(added_group) == 2
+    ), "Additional items added to the Group upon creation."

--- a/tests/test_group_layer_controls.py
+++ b/tests/test_group_layer_controls.py
@@ -1,18 +1,19 @@
 from napari._qt.layer_controls.qt_image_controls import QtImageControls
 from napari._qt.layer_controls.qt_points_controls import QtPointsControls
 from napari.layers import Image, Points
+from napari_experimental.group_layer import GroupLayer
 from napari_experimental.group_layer_controls import (
     QtGroupLayerControls,
     QtGroupLayerControlsContainer,
 )
 
 
-def test_controls_selection(make_napari_viewer, group_layer_data):
+def test_controls_selection(make_napari_viewer, group_layer_data: GroupLayer):
     """Test that group layer controls initialise with the correct widget, and
     match changes to the selected item."""
     viewer = make_napari_viewer()
     # Add an empty group also
-    group_layer_data.add_new_item()
+    group_layer_data.add_new_group()
 
     # Initialise with image item selected
     image_item = group_layer_data[1]
@@ -41,7 +42,9 @@ def test_controls_selection(make_napari_viewer, group_layer_data):
     ), "Current widget doesn't match selected group layer"
 
 
-def test_controls_insertion(make_napari_viewer, group_layer_data, blobs):
+def test_controls_insertion(
+    make_napari_viewer, group_layer_data: GroupLayer, blobs: Points
+):
     """Test that insertions into group layers are reflected in the controls
     widgets"""
     viewer = make_napari_viewer()
@@ -56,7 +59,7 @@ def test_controls_insertion(make_napari_viewer, group_layer_data, blobs):
     new_layer = Image(
         blobs, scale=(1, 2), translate=(20, 15), name="new-blobs"
     )
-    group_layer_data.add_new_item(layer_ptr=new_layer)
+    group_layer_data.add_new_layer(layer_ptr=new_layer)
 
     # Check that adding an item to group layers, also appears in the widgets
     assert len(group_layer_data) == n_items + 1

--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -68,14 +68,14 @@ def test_double_click_edit(group_layer_widget, double_click_on_view):
     assert group_layers_view.state() == group_layers_view.EditingState
 
 
-def test_layer_sync(make_napari_viewer, blobs, points):
+def test_layer_sync(make_napari_viewer, image_layer, points_layer):
     """
     Test the synchronisation between the widget and the main LayerList.
     This test will be redundant when the plugin functionality replaces the
     main viewer functionality.
     """
     viewer = make_napari_viewer()
-    viewer.add_image(blobs)
+    viewer.add_layer(image_layer)
 
     widget = GroupLayerWidget(viewer)
     assert len(widget.group_layers) == 1
@@ -83,7 +83,7 @@ def test_layer_sync(make_napari_viewer, blobs, points):
     # Check that adding a layer to the viewer means it is also added to
     # the group layers view.
 
-    viewer.add_points(points)
+    viewer.add_layer(points_layer)
     assert len(widget.group_layers) == 2
 
     # Check that reordering the layer order in the group layers view
@@ -105,3 +105,11 @@ def test_layer_sync(make_napari_viewer, blobs, points):
         strict=True,
     ):
         assert in_viewer is in_widget
+
+    # Deletion in main viewer results in deletion in group layers viewer
+    viewer.layers.remove(points_layer)
+    assert len(widget.group_layers) == 1
+    assert image_layer is widget.group_layers[0].layer
+    # Deletion in group layers viewer results in deletion in main viewer
+    widget.group_layers.remove_layer_item(image_layer)
+    assert len(viewer.layers) == 0

--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -5,7 +5,7 @@ from qtpy.QtWidgets import QWidget
 
 
 @pytest.fixture()
-def group_layer_widget(make_napari_viewer, blobs):
+def group_layer_widget(make_napari_viewer, blobs) -> GroupLayerWidget:
     viewer = make_napari_viewer()
     viewer.add_image(blobs)
     return GroupLayerWidget(viewer)
@@ -16,12 +16,12 @@ def test_widget_creation(make_napari_viewer_proxy) -> None:
     assert isinstance(GroupLayerWidget(viewer), QWidget)
 
 
-def test_rename_group_layer(group_layer_widget):
+def test_rename_group_layer(group_layer_widget: GroupLayerWidget):
     group_layers_view = group_layer_widget.group_layers_view
     group_layers_model = group_layers_view.model()
 
     # Add an empty group layer
-    group_layer_widget.group_layers.add_new_item()
+    group_layer_widget.group_layers.add_new_group()
 
     # Check current name
     new_name = "renamed-group"

--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -99,10 +99,9 @@ def test_layer_sync(make_napari_viewer, image_layer, points_layer):
     # Move layer at position 1 to position 0
     widget.group_layers.move((1,), (0,))
     # Viewer should have auto-synced these changes
-    for in_viewer, in_widget in zip(
+    for in_viewer, in_widget in zip(  # noqa: B905
         reversed(viewer.layers),
         [node.layer for node in widget.group_layers],
-        strict=True,
     ):
         assert in_viewer is in_widget
 

--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -90,10 +90,9 @@ def test_layer_sync(make_napari_viewer, image_layer, points_layer):
     # forces an update in the main viewer.
     # However, don't forget that the ordering is REVERSED in the GUI, so
     # viewer.layers[-1] == widget.group_layers[0], etc.
-    for in_viewer, in_widget in zip(
+    for in_viewer, in_widget in zip(  # noqa: B905
         reversed(viewer.layers),
         [node.layer for node in widget.group_layers],
-        strict=True,
     ):
         assert in_viewer is in_widget
     # Move layer at position 1 to position 0


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #9 

**What does this PR do?**

- Adds required functionality for the `GroupLayer`s widget to impose the layer order back onto the main viewer.
- Streamlines the functionality for adding and removing `Node`s and `Group`s via `add_new_{layer,group}` methods.
- Links the removal or addition of layers in the main viewer and group layers viewer, so if a LAYER item is added/removed in one, it will also be removed in the other.
- Adds tests for the functionality introduced.

It should be noted that re-ordering the layers in the main LayerList view does not change the corresponding order in the GroupLayers view. This is because:
- We envision that the GroupLayers view and standard LayerList view should not be used in tandem, and ultimate the goal is for the GroupLayers view to supersede the main viewer when integrated into the core codebase. (In which case, much of the functionality introduced in this PR will no longer be needed.) [Comment](https://github.com/brainglobe/napari-experimental/issues/9#issuecomment-2196422912)
- There is an ambiguity with regards to retaining the structure of the groups if the layers are manipulated in the main LayerList, which has no such group concepts. [Comment](https://github.com/brainglobe/napari-experimental/issues/9#issuecomment-2196403631)

## References

Closes #9 

## How has this PR been tested?

- Local testing and interaction with `napari`
- Addition of unit tests for backend functionality

## Is this a breaking change?

## Does this PR require an update to the documentation?

Adding docstrings got sucked into #27, which targets this branch.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
