### PR TITLE
Allows toggling visibility of group layers

### DIFF
--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -32,6 +32,19 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
     def name(self, value: str) -> None:
         self._name = value
 
+    @property
+    def visible(self):
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool) -> None:
+        for item in self.traverse():
+            if item.is_group():
+                item._visible = value
+            else:
+                item.layer.visible = value
+        self._visible = value
+
     def __init__(
         self,
         *items_to_include: Layer | GroupLayerNode | GroupLayer,
@@ -67,6 +80,9 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
 
         # If selection changes on this node, propagate changes to any children
         self.selection.events.changed.connect(self.propagate_selection)
+
+        # Default to group being visible
+        self._visible = True
 
     def _check_already_tracking(
         self, layer_ptr: Layer, recursive: bool = True

--- a/src/napari_experimental/group_layer_actions.py
+++ b/src/napari_experimental/group_layer_actions.py
@@ -35,8 +35,9 @@ class GroupLayerActions:
         ]
 
     def _toggle_visibility(self):
-        """Toggle the visibility of all selected layers inside the
-        group layers"""
+        """Toggle the visibility of all selected groups and layers. If some
+        selected groups/layers are inside others, then prioritise those
+        highest in the tree."""
 
         # Remove any selected items that are inside other selected groups
         # e.g. if a group is selected and also a layer inside it, toggling the

--- a/src/napari_experimental/group_layer_actions.py
+++ b/src/napari_experimental/group_layer_actions.py
@@ -31,10 +31,29 @@ class GroupLayerActions:
     def _toggle_visibility(self):
         """Toggle the visibility of all selected layers inside the
         group layers"""
-        for item in self.group_layers.selection:
+
+        # Remove any selected items that are inside other selected groups
+        # e.g. if a group is selected and also a layer inside it, toggling the
+        # visibility will give odd results as toggling the group will toggle
+        # the layer, then toggling the layer will toggle it again. We're
+        # assuming groups higher up the tree have priority.
+        items_to_toggle = self.group_layers.selection.copy()
+        items_to_keep = []
+        for sel_item in self.group_layers.selection:
+            if sel_item.is_group():
+                for item in items_to_toggle:
+                    if item not in sel_item or item == sel_item:
+                        items_to_keep.append(item)
+                items_to_toggle = items_to_keep
+                items_to_keep = []
+
+        # Toggle the visibility of the relevant selection
+        for item in items_to_toggle:
             if not item.is_group():
                 visibility = item.layer.visible
                 item.layer.visible = not visibility
+            else:
+                item.visible = not item.visible
 
 
 class ContextMenu(QMenu):

--- a/src/napari_experimental/group_layer_delegate.py
+++ b/src/napari_experimental/group_layer_delegate.py
@@ -112,14 +112,10 @@ class GroupLayerDelegate(LayerDelegate):
         """Show the group layer context menu.
         To add a new item to the menu, update the GroupLayerActions.
         """
-        item = index.data(ItemRole)
+        if not hasattr(self, "_context_menu"):
+            self._group_layer_actions = GroupLayerActions(model._root)
+            self._context_menu = ContextMenu(
+                self._group_layer_actions, parent=parent
+            )
 
-        # For now, don't show the right click context menu for groups.
-        if not item.is_group():
-            if not hasattr(self, "_context_menu"):
-                self._group_layer_actions = GroupLayerActions(model._root)
-                self._context_menu = ContextMenu(
-                    self._group_layer_actions, parent=parent
-                )
-
-            self._context_menu.exec_(pos)
+        self._context_menu.exec_(pos)

--- a/src/napari_experimental/group_layer_qt.py
+++ b/src/napari_experimental/group_layer_qt.py
@@ -64,7 +64,11 @@ class QtGroupLayerModel(QtNodeTreeModel[GroupLayer]):
                     else Qt.CheckState.Unchecked
                 )
             else:
-                return Qt.CheckState.Checked
+                return (
+                    Qt.CheckState.Checked
+                    if item.visible
+                    else Qt.CheckState.Unchecked
+                )
 
         return super().data(index, role)
 
@@ -83,6 +87,17 @@ class QtGroupLayerModel(QtNodeTreeModel[GroupLayer]):
                 item.layer.visible = (
                     Qt.CheckState(value) == Qt.CheckState.Checked
                 )
+            else:
+                item.visible = Qt.CheckState(value) == Qt.CheckState.Checked
+
+                # Changing the visibility of a group will affect all its
+                # children - emit data changed for them too
+                for child_item in item.traverse():
+                    child_index = self.nestedIndex(
+                        child_item.index_from_root()
+                    )
+                    self.dataChanged.emit(child_index, child_index, [role])
+
         else:
             return super().setData(index, value, role=role)
 

--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -30,13 +30,13 @@ def group_layer_widget_with_nested_groups(
 
     # Add a group layer with an image layer and point layer inside. One is
     # visible and the other is not
-    group_layers.add_new_item()
+    group_layers.add_new_group()
     new_group = group_layers[1]
 
     image_layer.visible = True
     points_layer.visible = False
-    new_group.add_new_item(layer_ptr=image_layer)
-    new_group.add_new_item(layer_ptr=points_layer)
+    group_layers.add_new_layer(layer_ptr=image_layer, location=(1, 0))
+    group_layers.add_new_layer(layer_ptr=points_layer, location=(1, 1))
     new_image = new_group[0]
     new_points = new_group[1]
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently group layer visibility can't be toggled + doesn't affect any layers inside

**What does this PR do?**
Allows toggling group layer visibility by clicking the 'eye' icon on its row, or via the right click menu options.

## References

Closes https://github.com/brainglobe/napari-experimental/issues/24

## How has this PR been tested?

Tests have been added for additional functionality.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
