### PR TITLE
Bump `test_and_deploy` updates to ARC-dev-branch

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -11,7 +11,7 @@ on:
       - "v**" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches:
-      - "*"
+      - "**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Updates to `test_and_deploy` were merged into main, this PR bumps the ARC-dev-branch to also contain the changes.