### PR TITLE
Fix ubuntu clicking simulation in tests

### DIFF
--- a/tests/test_group_layer_widget.py
+++ b/tests/test_group_layer_widget.py
@@ -10,7 +10,11 @@ from qtpy.QtWidgets import QWidget
 def group_layer_widget(make_napari_viewer, blobs):
     viewer = make_napari_viewer()
     viewer.add_image(blobs)
-    return GroupLayerWidget(viewer)
+
+    _, plugin_widget = viewer.window.add_plugin_dock_widget(
+        "napari-experimental", "Show Grouped Layers"
+    )
+    return plugin_widget
 
 
 def test_widget_creation(make_napari_viewer_proxy) -> None:


### PR DESCRIPTION
Looks like on Ubuntu, Qt really cares about inheritance and the [test failures here](https://github.com/brainglobe/napari-experimental/actions/runs/9792505423/job/27044749174?pr=29) were caused because were instantiating a `GroupLayersWidget` that was orphaned from the main viewer. 

Our group_layer_widget fixture was previously doing this:

```python
viewer = make_napari_viewer()
viewer.add_image(blobs)
return GroupLayerWidget(viewer) 
```

which means that the returned widget isn't actually connected to the napari window. Changing it to return the widget produced when the plugin is activated (thus giving it a parent) means everything is passing:

```python
viewer = make_napari_viewer()
viewer.add_image(blobs)
_, plugin_widget = viewer.window.add_plugin_dock_widget("napari-experimental", "Show Grouped Layers")
return plugin_widget
```