### PR TITLE
Fix bugs relating to empty `GroupLayers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ In order to preserve the user's intuitive understanding of "layers higher up in 
 
 ### Known bugs and issues (breaking)
 
-- Seg-fault when adding an empty group to another empty group <https://github.com/brainglobe/napari-experimental/issues/12>
-
 ### Development Tasks
 
 - Create a standalone docs site that expands on the implementation details section.

--- a/src/napari_experimental/group_layer.py
+++ b/src/napari_experimental/group_layer.py
@@ -458,6 +458,59 @@ class GroupLayer(Group[GroupLayerNode], GroupLayerNode):
                 order.append(item.index_from_root())
         return order
 
+    def index(
+        self,
+        value: GroupLayerNode,
+        start: int = 0,
+        stop: int = None,
+    ) -> int:
+        """
+        Note this is identical to the parent method, save for the comparison
+        operation that returns the index. CF
+
+        ```
+        v = convert(self[i])
+        if v is value:
+        ```
+
+        vs in the parent class
+
+        ```
+        v = convert(self[i])
+        if v is value or v == value:
+        ```
+
+        This is because Group comparison inherits from _typed, which compares
+        the ._list items in a Group. This causes empty GroupLayers to be
+        identical, resulting in recursion loops and seg-faults when cleaning.
+
+        By contrast, implementing the __eq__ method means this class isn't
+        hashable any more. Attempting to implement both __hash__ and __eq__ is
+        not simple either (since GroupLayers are inherently mutable)! As such,
+        it is easiest to fall back to memory comparison, since we know that
+        distinct GroupLayers will occupy different places in memory, and should
+        only ever store pointers to other objects and not copies themselves.
+        """
+        if start is not None and start < 0:
+            start = max(len(self) + start, 0)
+        if stop is not None and stop < 0:
+            stop += len(self)
+
+        convert = self._lookup.get(type(value), lambda x: x)
+
+        for i in self._iter_indices(start, stop):
+            v = convert(self[i])
+            if v is value:
+                return i
+
+        raise ValueError(
+            trans._(
+                "{value!r} is not in list",
+                deferred=True,
+                value=value,
+            )
+        )
+
     def is_group(self) -> bool:
         """
         Determines if this item is a genuine Node, or a branch containing


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently there are a number of issues when working with empty `GroupLayer` objects:
- #12 
- Adding a `Layer` via drag-and-drop to an empty `GroupLayer` when there are other empty `GroupLayer`s in the tree causes the `Layer` to be added to the first empty `GroupLayer`, not the selected one.
- We hit sporadic recursion errors when attempting to put `GroupLayer`s inside other `GroupLayer`s.

The above issues are caused by the comparison operation `==` on `GroupLayer`: this is inheriting from a napari object (`TypedMutableSequence`) which compares the `._list` attributes of the `GroupLayer`. Since empty lists are equal, thus it is that empty `GroupLayer`s are equal. In particular, this means that asking the `GroupLayer.index` method for the index of an empty `GroupLayer`, the index of the _first_ such `GroupLayer` would be returned and not necessarily the `GroupLayer` we were concerned with!

- This caused #12 since it meant that a `GroupLayer` was to be placed inside itself (moving an empty `GroupLayer` inside a `GroupLayer` resulted in moving the first empty `GroupLayer` inside itself as references were incorrect).
- Likewise, we hit occasional recursion errors because the selection propagation would continually propagate a selection to an object with a reference to itself.
- And dragging-and-dropping `Layer`s always got added to the first empty group (if placed into any such empty group) because the `index` method would point to the first empty group in the list.

**What does this PR do?**

Implements an explicit `__eq__` method for the `GroupLayer` class, which fixes the issue of comparison. Since the `GroupLayerControls` need to use the `GroupLayer`s as keys, they must also be hashable, so we also need an appropriate `__hash__` method. Use of `id(self)` is not sufficient because the way napari works when moving objects is to delete them and instantiate a copy, thus changing the memory address of said object and hence `id(self)` is _not_ invariant!

As a result, `GroupLayer` (the class) now tracks a `__next_uid` `int` which serves as our hash value for a given instance. When an instance is created, the `uid` property is set to the next available value, and then the next available value increments by 1. `__hash__` can then fetch the `uid` attribute which has all required properties of a hash, and `__eq__` can now be overwritten.

This does mean that we have the following (somewhat unintuitive) behaviour for `GroupLayer`s now: two `GroupLayer` instances, instantiated with the same inputs, will _not_ be equal (by neither `==` or `is`).

However, I would argue this is actually desirable from our POV. `GroupLayer`s are an organisational tool, so two instances that contain the same nested structure should not be considered equal. The user may want to have one visible and the other invisible, for example. Or one translated relative to the other, with a different level of saturation / contrast, etc.

## References

Closes #12. It also fixes the (unreported & aforementioned) bug @alessandrofelder found concerning moving `Layer`s into empty `GroupLayer`s.

## How has this PR been tested?

## Is this a breaking change?

## Does this PR require an update to the documentation?

We can cross off one "breaking issue" from the section we have in the README :smile: 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
