### PR TITLE
expand docs for group layers, delegates and context menu

### DIFF
--- a/docs/source/group_layers/classes/group_layer_and_nodes.md
+++ b/docs/source/group_layers/classes/group_layer_and_nodes.md
@@ -48,6 +48,17 @@ This is a safe property to use as the hash value since it fulfils all necessary 
 This in itself is a (semi-)desirable situation for us though: even if two `GroupLayer`s contain the same nested structure, name, etc, this does not mean they are identical in terms of how the user has decided to organise them within the tree structure.
 However, care should be taken when comparing for identical `GroupLayer` instances - if you want to check equality of `GroupLayer` attributes, you will need to explicitly check these via `GroupLayer1.<attribute> == GroupLayer2.<attribute>`.
 
+## Propagation of selection
+
+Each `GroupLayer` within a tree has its own `.selection` containing a list of `GroupLayer` or `GroupLayerNode`.
+These selected items can be at any level within the tree (not just restricted to direct children).
+
+To keep selection changes synced at all levels in the tree, the `GroupLayer`'s `propagate_selection` function is called every time the selection changes.
+This propagates the selection to any nested `Group Layer`s inside of it.
+Note that this propagation only happens in one direction (from parents to children)!
+Also, only the selected items are currently updated with `propagate_selection`.
+This means that, for example, the 'active' selected item might not be synced correctly to other levels in the tree.
+
 ## API Reference
 
 ### `GroupLayerNode`

--- a/docs/source/group_layers/implementation.md
+++ b/docs/source/group_layers/implementation.md
@@ -26,6 +26,8 @@ The key classes implemented in this plugin are
 - `GroupLayerNode`, `GroupLayer`: These are the Python classes that provide the tree-structure that group layers require. We expand on these below.
 - `QtGroupLayerControls`, `QtGroupLayerControlsContainer`: These classes are used to build the "control box" that the plugin provides when selecting a layer within the plugin. For all intents and purposes it mimics the existing napari layer viewer context window, but also reacts when selecting a group layer.
 - `QtGroupLayerModel`, `QtGroupLayerView`: These subclass from the appropriate Qt abstract classes, and provide the model/tree infrastructure for working with `GroupLayers`. Beyond this, they do not contain any remarkable functionality beyond patching certain methods for consistency with the data being handled / displayed.
+- `GroupLayerDelegate`: handles display of thumbnails / icons on layers and group layers, as well as displaying the right click context menu.
+- `GroupLayerActions`, `ContextMenu`: These classes are used to build the right click context menu. `GroupLayerActions` can be expanded to add more options to this menu.
 
 You can navigate to the respective pages for further information on each of these classes:
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -53,7 +53,7 @@ When a new version is released (tag on `main`) or a push to `main` occurs with c
 
 ## Contributing
 
-You can report bugs and request features by [raising an issue](https://github.com/brainglobe/napari-experimental/issues/23) on the GitHub repository - we have a few templates to help you fill out an issue if you haven't done so before.
+You can report bugs and request features by [raising an issue](https://github.com/brainglobe/napari-experimental/issues/) on the GitHub repository - we have a few templates to help you fill out an issue if you haven't done so before.
 
 We follow the same [contribution guidelines](https://napari.org/stable/developers/index.html) as the napari project.
 Contributions are welcome to any of the plugins via pull request, and will be subject to review from appropriate maintainers.


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**What does this PR do?**
- Adds info about propagation of selection in group layers
- Adds a short description of `GroupDelegate` and context menu classes
- Changes the 'raising an issue' link to not point to a specific issue

I looked through the various classes I wrote, and I wasn't sure any would require extra description in a docs page (except the selection propagation). For now I've left just a brief description in the `implementation` page, but happy to add pages for each with a brief description + autodoc if you'd prefer.

## References
None

## How has this PR been tested?
N/A

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Documentation updated.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
