### PR TITLE
Depend on napari>=0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 requires-python = ">=3.9"
-dependencies = ["numpy", "napari", "magicgui", "pyqt5", "qtpy", "scikit-image"]
+dependencies = ["numpy", "napari>=0.5", "magicgui", "pyqt5", "qtpy", "scikit-image"]
 dynamic = ["version"]
 
 [project.entry-points."napari.manifest"]


### PR DESCRIPTION

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The ultimate goal is to move features from here into core napari.
Now that napari 0.5 is out, this is what we should depend on as a consequence.
We also keep a version of the tests running with `napari` main branch.

**What does this PR do?**

Pin napari version from below to be >=0.5

## References
Closes #17 

## How has this PR been tested?

Usual CI

## Is this a breaking change?
We may break compatibility with <0.5 to some extent, but that is intended.

## Does this PR require an update to the documentation?

Nope

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
