### PR TITLE
Remove `napari-hub` shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-experimental.svg?color=green)](https://python.org)
 [![tests](https://github.com/brainglobe/napari-experimental/workflows/tests/badge.svg)](https://github.com/brainglobe/napari-experimental/actions)
 [![codecov](https://codecov.io/gh/brainglobe/napari-experimental/branch/main/graph/badge.svg)](https://codecov.io/gh/brainglobe/napari-experimental)
-[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-experimental)](https://napari-hub.org/plugins/napari-experimental)
 
 ## Overview
 


### PR DESCRIPTION
Now that napari-hub is community maintained the https://api.napari-hub.org/shields/{package_name} endpoint is no longer valid.

Removing the badge for now.

Tracked in https://github.com/napari/hub-lite/issues/88 